### PR TITLE
chore(deps): bump the go_modules group across 1 directory with 2 updates

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/TBXark/subconverter
 
 go 1.23
+toolchain go1.24.1
 
 require github.com/gin-gonic/gin v1.10.0
 
@@ -25,10 +26,10 @@ require (
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect
 	github.com/ugorji/go/codec v1.2.12 // indirect
 	golang.org/x/arch v0.8.0 // indirect
-	golang.org/x/crypto v0.23.0 // indirect
-	golang.org/x/net v0.25.0 // indirect
-	golang.org/x/sys v0.20.0 // indirect
-	golang.org/x/text v0.15.0 // indirect
+	golang.org/x/crypto v0.36.0 // indirect
+	golang.org/x/net v0.38.0 // indirect
+	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/text v0.23.0 // indirect
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
Bumps the go_modules group with 2 updates in the / directory: [golang.org/x/crypto](https://github.com/golang/crypto) and [golang.org/x/net](https://github.com/golang/net).


Updates `golang.org/x/crypto` from 0.23.0 to 0.35.0
- [Commits](https://github.com/golang/crypto/compare/v0.23.0...v0.35.0)

Updates `golang.org/x/net` from 0.25.0 to 0.38.0
- [Commits](https://github.com/golang/net/compare/v0.25.0...v0.38.0)

---
updated-dependencies:
- dependency-name: golang.org/x/crypto dependency-version: 0.35.0 dependency-type: indirect dependency-group: go_modules
- dependency-name: golang.org/x/net dependency-version: 0.38.0 dependency-type: indirect dependency-group: go_modules ...